### PR TITLE
do not start the chatbot open on mobile if explicitly told not to fro…

### DIFF
--- a/resources/assets/js/opendialog-bot.js
+++ b/resources/assets/js/opendialog-bot.js
@@ -211,7 +211,7 @@ if (window.openDialogSettings) {
 
       if (urlParams.has('chat_open') && urlParams.get('chat_open') === 'true') {
         openChatWindow();
-      } else if (window.innerWidth <= mobileWidth || settings.general.startMinimized) {
+      } else if ((!window.openDialogSettings.general.open && window.innerWidth <= mobileWidth) || settings.general.startMinimized) {
         query = `${query}&hide=true`;
         openChatWindow();
 


### PR DESCRIPTION
…m the webchat settings


The chatbot was always opening fully on mobile screens (less than 480 width) even if the general.close setting was set to false.

This puts in a check for that property