### PR TITLE
removes the `chatbot-no-scroll` class from body when closing the bot …

### DIFF
--- a/resources/assets/js/opendialog-bot.js
+++ b/resources/assets/js/opendialog-bot.js
@@ -131,6 +131,7 @@ function drawOpenCloseIcons() {
     } else {
       element.parentNode.removeChild(element);
       div.classList.remove('opened');
+      document.body.classList.remove('chatbot-no-scroll');
     }
   }, false);
 


### PR DESCRIPTION
…with the open/close icons

Ensures the no-scroll class is removed from the body when the chatbot is closed