### PR TITLE
Fixing bug with header height

### DIFF
--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -21,6 +21,7 @@ body {
   right: 0 !important;
 
   .sc-header {
+    flex: 1;
     border-radius: 0;
     box-shadow: none;
     text-align: center;

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -24,7 +24,7 @@ body {
     border-radius: 0;
     box-shadow: none;
     text-align: center;
-    min-height: 48px;
+    height: 48px;
     padding: 7px 10px;
 
     .sc-header--expand-button {


### PR DESCRIPTION
This PR fixes a bug introduced by opendialogai/vue-beautiful-chat#20 which caused the webchat header to attempt to fill as much space as possible.