### PR TITLE
Feature/split team name logo

### DIFF
--- a/resources/assets/js/components/OpenDialogChat.vue
+++ b/resources/assets/js/components/OpenDialogChat.vue
@@ -577,6 +577,10 @@ export default {
           this.agentProfile.teamName = general.teamName;
         }
 
+        if (general.logo) {
+            this.agentProfile.imageUrl = general.logo;
+        }
+
         if (general.messageDelay) {
           this.messageDelay = general.messageDelay;
         }

--- a/resources/assets/js/components/WebChat.vue
+++ b/resources/assets/js/components/WebChat.vue
@@ -193,11 +193,6 @@ export default {
         this.dateTimezoneFormat(lastMessage);
       }
     },
-    isOpen(isOpen) {
-      if (isOpen) {
-        this.agentProfile.imageUrl = null;
-      }
-    },
     loading(isLoading) {
       if (!isLoading) {
         setTimeout(() => {

--- a/src/WebchatSetting.php
+++ b/src/WebchatSetting.php
@@ -18,6 +18,7 @@ class WebchatSetting extends Model
     public const GENERAL                   = 'general';
     public const URL                       = 'url';
     public const TEAM_NAME                 = 'teamName';
+    public const LOGO                      = 'logo';
     public const VALID_PATH                = 'validPath';
     public const MESSAGE_DELAY             = 'messageDelay';
     public const OPEN                      = 'open';
@@ -123,6 +124,7 @@ class WebchatSetting extends Model
                 WebchatSetting::STRING => [
                     WebchatSetting::URL,
                     WebchatSetting::TEAM_NAME,
+                    WebchatSetting::LOGO,
                     WebchatSetting::CHATBOT_CSS_PATH,
                     WebchatSetting::CHATBOT_FULLPAGE_CSS_PATH,
                     WebchatSetting::PAGE_CSS_PATH,


### PR DESCRIPTION
This PR:
- Adds a new LOGO webchat setting
- Retrieves it and sets it to the internal `agentProfile.inageUrl` variable
- removes the function that sets the imageUrl to null on re-opening the chatbot


If team name and logo are set, the resulting header div looks like this:

![image](https://user-images.githubusercontent.com/35454728/74466087-7d232800-4e8e-11ea-8d9e-b7fd22773c41.png)
