### PR TITLE
Feature/skip buttons

### DIFF
--- a/resources/assets/js/components/ChatWindow.vue
+++ b/resources/assets/js/components/ChatWindow.vue
@@ -304,7 +304,7 @@ export default {
       if (this.messages.length > 0) {
         const lastMessage = this.messages[this.messages.length - 1]
         if (lastMessage.type === 'button' && lastMessage.data.external) {
-          return lastMessage.data.buttons
+          return lastMessage.data.buttons.filter(btn => btn.type !== 'skip')
         }
       }
 

--- a/resources/assets/js/components/WebChat.vue
+++ b/resources/assets/js/components/WebChat.vue
@@ -434,10 +434,12 @@ export default {
         })
       }
 
-      chatService.sendRequest(newMsg, this).then(
+      /* chatService.sendRequest(newMsg, this).then(
         response => chatService.sendResponseSuccess(response, newMsg, this),
         () => chatService.sendResponseError(null, newMsg, this)
-      );
+      ); */
+
+      this.$store.dispatch('sendMessage', {sentMsg: newMsg, webChat: this})
     },
     userInputFocus() {
       if (!this.isExpand && !this.isMobile) {

--- a/resources/assets/js/components/layout/ExternalButtons.vue
+++ b/resources/assets/js/components/layout/ExternalButtons.vue
@@ -75,13 +75,13 @@ export default {
         this.showLeftArrow = false
         this.showRightArrow = false
 
-        this.$nextTick(() => {
+        setTimeout(() => {
           if (this.$refs.externalButtonsRow) {
             if (this.$refs.externalButtonsRow.scrollWidth > (this.$refs.externalButtonsRow.offsetWidth + this.$refs.externalButtonsRow.scrollLeft)) {
               this.showRightArrow = true
             }
           }
-        })
+        }, 100)
       }
     }
   },

--- a/resources/assets/js/components/layout/UserInput.vue
+++ b/resources/assets/js/components/layout/UserInput.vue
@@ -1,14 +1,15 @@
 <template>
   <div class="od-user-input">
     <ExternalButtons
+      v-show="lastUsefulMessage.type === 'button' && lastUsefulMessage.data.external"
       :externalButtons="externalButtons"
       :animate="animateExternalButtons"
-      :shouldClear="lastMessage.data.clear_after_interaction"
+      :shouldClear="lastUsefulMessage.data.clear_after_interaction"
       v-on:sendExternalButton="_submitExternalButton"
     />
 
     <Autocomplete
-      v-if="lastMessage.type === 'autocomplete'"
+      v-if="lastUsefulMessage.type === 'autocomplete'"
       :data="lastMessage.data"
       :message="lastMessage"
       :onButtonClick="onButtonClick"
@@ -68,7 +69,7 @@
 
 
 <script>
-import {mapState} from 'vuex';
+import {mapState, mapGetters} from 'vuex';
 import ExternalButtons from "./ExternalButtons.vue";
 import EndChatButton from "./EndChatButton";
 import Autocomplete from '../messages/Autocomplete';
@@ -138,7 +139,10 @@ export default {
     },
     ...mapState({
       textLimit: state => state.messageMetaData.textLimit
-    })
+    }),
+    ...mapGetters([
+      'lastUsefulMessage'
+    ])
   },
   created() {
     this.onTextChange = _.debounce(this.onTextChangeForDebouncing, 500);

--- a/resources/assets/js/components/layout/UserInput.vue
+++ b/resources/assets/js/components/layout/UserInput.vue
@@ -4,7 +4,7 @@
       v-show="lastUsefulMessage.type === 'button' && lastUsefulMessage.data.external"
       :externalButtons="externalButtons"
       :animate="animateExternalButtons"
-      :shouldClear="lastUsefulMessage.data.clear_after_interaction"
+      :shouldClear="lastUsefulMessage.data ? lastUsefulMessage.data.clear_after_interaction : null"
       v-on:sendExternalButton="_submitExternalButton"
     />
 

--- a/resources/assets/js/components/layout/UserInput.vue
+++ b/resources/assets/js/components/layout/UserInput.vue
@@ -10,8 +10,8 @@
 
     <Autocomplete
       v-if="lastUsefulMessage.type === 'autocomplete'"
-      :data="lastMessage.data"
-      :message="lastMessage"
+      :data="lastUsefulMessage.data"
+      :message="lastUsefulMessage"
       :onButtonClick="onButtonClick"
     />
 

--- a/resources/assets/js/components/layout/UserInput.vue
+++ b/resources/assets/js/components/layout/UserInput.vue
@@ -1,20 +1,5 @@
 <template>
   <div class="od-user-input">
-    <ExternalButtons
-      v-show="lastUsefulMessage.type === 'button' && lastUsefulMessage.data.external"
-      :externalButtons="externalButtons"
-      :animate="animateExternalButtons"
-      :shouldClear="lastUsefulMessage.data ? lastUsefulMessage.data.clear_after_interaction : null"
-      v-on:sendExternalButton="_submitExternalButton"
-    />
-
-    <Autocomplete
-      v-if="lastUsefulMessage.type === 'autocomplete'"
-      :data="lastUsefulMessage.data"
-      :message="lastUsefulMessage"
-      :onButtonClick="onButtonClick"
-    />
-
     <div v-if="file" class="od-file-container">
       <span class="od-icon-file-message">
         <img src="../assets/file.svg" alt="genericFileIcon" height="15" />
@@ -25,7 +10,23 @@
       </span>
     </div>
 
+    <ExternalButtons
+      v-show="userInputType === 'external-button'"
+      :externalButtons="externalButtons"
+      :animate="animateExternalButtons"
+      :shouldClear="currentMessage.data ? currentMessage.data.clear_after_interaction : null"
+      v-on:sendExternalButton="_submitExternalButton"
+    />
+
+    <Autocomplete
+      v-if="userInputType === 'autocomplete'"
+      :data="currentMessage.data"
+      :message="currentMessage"
+      :onButtonClick="onButtonClick"
+    />
+
     <form
+      v-if="userInputType === 'default'"
       class="od-user-input__form"
       :class="{active: inputActive, disabled: !contentEditable}"
     >
@@ -69,7 +70,7 @@
 
 
 <script>
-import {mapState, mapGetters} from 'vuex';
+import {mapState} from 'vuex';
 import ExternalButtons from "./ExternalButtons.vue";
 import EndChatButton from "./EndChatButton";
 import Autocomplete from '../messages/Autocomplete';
@@ -138,11 +139,10 @@ export default {
       }
     },
     ...mapState({
-      textLimit: state => state.messageMetaData.textLimit
-    }),
-    ...mapGetters([
-      'lastUsefulMessage'
-    ])
+      textLimit: state => state.messageMetaData.textLimit,
+      currentMessage: state => state.currentMessage,
+      userInputType: state => state.userInputType
+    })
   },
   created() {
     this.onTextChange = _.debounce(this.onTextChangeForDebouncing, 500);

--- a/resources/assets/js/components/layout/UserInput.vue
+++ b/resources/assets/js/components/layout/UserInput.vue
@@ -132,7 +132,7 @@ export default {
       file: null,
       inputActive: false,
       textEntered: false,
-      msgText: null
+      msgText: ''
     };
   },
   computed: {

--- a/resources/assets/js/components/layout/UserInput.vue
+++ b/resources/assets/js/components/layout/UserInput.vue
@@ -65,7 +65,9 @@
         />
       </div>
     </form>
-    <button v-if="skipButton" @click.once="onButtonClick(skipButton, currentMessage);" class="od-user-input__skip">{{skipButton.text}}</button>
+    <div class="od-user-input__skip-wrapper">
+      <button v-if="skipButton" @click.once="onButtonClick(skipButton, currentMessage);" class="od-user-input__skip">{{skipButton.text}}<span>&rsaquo;</span></button>
+    </div>
   </div>
 </template>
 
@@ -363,6 +365,27 @@ export default {
     .od-send-btn__icon {
       display: none;
       margin-left: 12px;
+    }
+  }
+
+  .od-user-input__skip-wrapper {
+    text-align: center;
+  }
+
+  .od-user-input__skip {
+    background-color: var(--od-user-input-background);
+    border: none;
+    border-radius: 14px;
+    box-shadow: 0px 4px 8px 0px rgba(189, 187, 182, 0.29);
+    color: var(--od-button-background);
+    font-size: 14px;
+    line-height: 19px;
+    margin: 16px auto;
+    padding: 5px 16px;
+
+    span {
+      font-size: 18px;
+      margin-left: 8px;
     }
   }
 }

--- a/resources/assets/js/components/layout/UserInput.vue
+++ b/resources/assets/js/components/layout/UserInput.vue
@@ -65,6 +65,7 @@
         />
       </div>
     </form>
+    <button v-if="skipButton" @click.once="onButtonClick(skipButton, currentMessage);" class="od-user-input__skip">{{skipButton.text}}</button>
   </div>
 </template>
 
@@ -142,7 +143,12 @@ export default {
       textLimit: state => state.messageMetaData.textLimit,
       currentMessage: state => state.currentMessage,
       userInputType: state => state.userInputType
-    })
+    }),
+    skipButton() {
+      if (this.currentMessage.type === 'button' && this.currentMessage.data.external) {
+        return this.currentMessage.data.buttons.find(btn => btn.type === 'skip')
+      }
+    }
   },
   created() {
     this.onTextChange = _.debounce(this.onTextChangeForDebouncing, 500);

--- a/resources/assets/js/components/messages/Autocomplete.vue
+++ b/resources/assets/js/components/messages/Autocomplete.vue
@@ -17,7 +17,8 @@
       <button v-show="searchTerm.length || results.length" class="od-autocomplete__submit" @click.prevent="_handleClick()">{{data.submit_text}}</button>
       <span v-if="textLimit" class="od-autocomplete__max-chars">{{searchTerm.length}}/{{textLimit}}</span>
     </div>
-    <div v-show="results.length" class="od-autocomplete__results">
+    <transition name="delayed-fade">
+      <div v-show="results.length" class="od-autocomplete__results">
       <p>{{data.title}}</p>
       <perfect-scrollbar class="od-autocomplete__scrollable">
         <ul class="od-autocomplete__results-list">
@@ -33,6 +34,7 @@
         </ul>
       </perfect-scrollbar>
     </div>
+    </transition>
   </div>
 </template>
 

--- a/resources/assets/js/components/messages/ButtonMessage.vue
+++ b/resources/assets/js/components/messages/ButtonMessage.vue
@@ -7,7 +7,7 @@
         emit : this.author === 'me',
     }]"
   >
-    <div class="mt reap od-message-button__text">
+    <div v-if="data.text" class="mt reap od-message-button__text">
       <span v-html="data.text" v-linkified></span>
       <template v-if="data.buttons.length && !data.external">
         <div class="od-message-button__inline-buttons">

--- a/resources/assets/js/components/messages/TypingMessage.vue
+++ b/resources/assets/js/components/messages/TypingMessage.vue
@@ -42,8 +42,8 @@ export default {
 
 .od-message-typing.mt {
   animation-duration: 0s;
-  background-color: transparent !important;
-  color: #efefeb !important;
+  background-color: transparent;
+  color: #efefeb;
   font-size: 14px;
   padding: 25px 20px 10px 5px;
 

--- a/resources/assets/js/services/ChatServices/WebChatMode.js
+++ b/resources/assets/js/services/ChatServices/WebChatMode.js
@@ -322,6 +322,8 @@ WebChatMode.prototype.sendResponseSuccess = function(response, sentMessage, webC
       sendMessageReceivedEvent(message, webChatComponent);
     }
   }
+
+  return webChatComponent.messageList
 };
 
 WebChatMode.prototype.sendResponseError = function(error, sentMessage, webChatComponent) {

--- a/resources/assets/js/services/ChatServices/WebChatMode.js
+++ b/resources/assets/js/services/ChatServices/WebChatMode.js
@@ -335,8 +335,6 @@ WebChatMode.prototype.sendResponseSuccess = function(response, sentMessage, webC
       }
     }
   })
-
-  //return webChatComponent.messageList
 };
 
 WebChatMode.prototype.sendResponseError = function(error, sentMessage, webChatComponent) {

--- a/resources/assets/js/services/ChatServices/WebChatMode.js
+++ b/resources/assets/js/services/ChatServices/WebChatMode.js
@@ -53,7 +53,7 @@ function sendMessageReceivedEvent (message, webChatComponent) {
 WebChatMode.prototype.sendResponseSuccess = function(response, sentMessage, webChatComponent) {
   if (response.data instanceof Array) {
     let index = 0;
-    let totalMessages = response.data.length;
+    let totalMessages = response.data.filter(msg => msg !== false).length;
     let typingMessage;
     let clearCtaText = true;
 
@@ -156,7 +156,7 @@ WebChatMode.prototype.sendResponseSuccess = function(response, sentMessage, webC
             webChatComponent.showMessages = true;
           }
 
-          if (!webChatComponent.hideTypingIndicatorOnInternalMessages && message.type !== 'autocomplete') {
+          if (!webChatComponent.hideTypingIndicatorOnInternalMessages) {
             if (messageIndex < totalMessages - 1) {
               webChatComponent.$nextTick(() => {
                 webChatComponent.$nextTick(() => {
@@ -180,6 +180,7 @@ WebChatMode.prototype.sendResponseSuccess = function(response, sentMessage, webC
         index += 1;
       }
     });
+
   } else if (response.data) {
     const message = response.data;
 

--- a/resources/assets/js/services/ChatServices/WebChatMode.js
+++ b/resources/assets/js/services/ChatServices/WebChatMode.js
@@ -51,43 +51,206 @@ function sendMessageReceivedEvent (message, webChatComponent) {
 }
 
 WebChatMode.prototype.sendResponseSuccess = function(response, sentMessage, webChatComponent) {
-  if (response.data instanceof Array) {
-    let index = 0;
-    let totalMessages = response.data.filter(msg => msg !== false).length;
-    let typingMessage;
-    let clearCtaText = true;
+  
 
-    response.data.forEach((message, i) => {
-      const messageIndex = index;
+  return new Promise((resolve, reject) => {
+    if (response.data instanceof Array) {
+      let index = 0;
+      let totalMessages = response.data.filter(msg => msg !== false).length;
+      let typingMessage;
+      let clearCtaText = true;
+  
+      response.data.forEach((message, i) => {
+        const messageIndex = index;
+  
+        if (message && message.type === "cta") {
+          if (clearCtaText) {
+            webChatComponent.ctaText = [];
+            clearCtaText = false;
+          }
+          if (webChatComponent.ctaText.length === 2) {
+            webChatComponent.ctaText.splice(0, 1);
+          }
+          webChatComponent.ctaText.push(message.data.text);
+  
+          totalMessages -= 1;
+        } else if (message.type === 'meta') {
+          webChatComponent.updateMessageMetaData(message);
+  
+          totalMessages -= 1;
+        } else if (!message) {
+          webChatComponent.contentEditable = true;
+        } else {
+          if (messageIndex === 0) {
+            if (
+              (webChatComponent.useBotName || webChatComponent.useBotAvatar) &&
+              !message.data.hideavatar
+            ) {
+              const authorMsg = webChatComponent.newAuthorMessage(message);
+  
+              webChatComponent.messageList.push(authorMsg);
+            }
+  
+            typingMessage = {
+              author: "them",
+              type: "typing",
+              mode: webChatComponent.modeData.mode,
+              data: {
+                animate: webChatComponent.messageAnimation
+              }
+            };
+            webChatComponent.messageList.push(typingMessage);
+          }
+  
+          setTimeout(() => {
+            webChatComponent.$emit("newMessage", message);
+  
+            /* eslint-disable no-param-reassign */
+            message.data.animate = webChatComponent.messageAnimation;
+  
+            if (
+              messageIndex === 0 ||
+              !webChatComponent.hideTypingIndicatorOnInternalMessages
+            ) {
+              typingMessage.type = message.type;
+              typingMessage.data = message.data;
+  
+              if (messageIndex === 0 && totalMessages > 1) {
+                typingMessage.data.first = true;
+              }
+  
+              if (messageIndex > 0 && messageIndex < totalMessages - 1) {
+                typingMessage.data.middle = true;
+              }
+  
+              if (messageIndex > 0 && messageIndex === totalMessages - 1) {
+                typingMessage.data.last = true;
+              }
+  
+              webChatComponent.$root.$emit("scroll-down-message-list");
+              setTimeout(() => {
+                webChatComponent.$root.$emit("scroll-down-message-list");
+              }, 50);
+            } else {
+              if (messageIndex > 0 && messageIndex === totalMessages - 1) {
+                /* eslint-disable no-param-reassign */
+                message.data.lastInternal = true;
+              }
+  
+              message.mode = webChatComponent.modeData.mode;
+              webChatComponent.messageList.push(message);
+            }
+  
+            if (message.data) {
+              webChatComponent.contentEditable = !message.data.disable_text;
+            }
+  
+            if (message.type === "fp-form") {
+              webChatComponent.showFullPageFormInputMessage(message);
+            }
+  
+            if (message.type === "fp-rich") {
+              webChatComponent.showFullPageRichInputMessage(message);
+            }
+  
+            if (message.type !== "fp-form" && message.type !== "fp-rich") {
+              webChatComponent.showFullPageFormInput = false;
+              webChatComponent.showFullPageRichInput = false;
+              webChatComponent.showMessages = true;
+            }
+  
+            if (!webChatComponent.hideTypingIndicatorOnInternalMessages) {
+              if (messageIndex < totalMessages - 1) {
+                webChatComponent.$nextTick(() => {
+                  webChatComponent.$nextTick(() => {
+                    typingMessage = {
+                      author: "them",
+                      type: "typing",
+                      mode: webChatComponent.modeData.mode,
+                      data: {
+                        animate: webChatComponent.messageAnimation
+                      }
+                    };
+                    webChatComponent.messageList.push(typingMessage);
+                  });
+                });
+              }
+            }
 
-      if (message && message.type === "cta") {
-        if (clearCtaText) {
-          webChatComponent.ctaText = [];
-          clearCtaText = false;
+            if (messageIndex >= totalMessages -1) {
+              resolve(webChatComponent.messageList)
+            }
+          }, (messageIndex + 1) * webChatComponent.messageDelay);
+  
+          sendMessageReceivedEvent(message, webChatComponent);
+  
+          index += 1;
         }
-        if (webChatComponent.ctaText.length === 2) {
-          webChatComponent.ctaText.splice(0, 1);
-        }
-        webChatComponent.ctaText.push(message.data.text);
-
-        totalMessages -= 1;
-      } else if (message.type === 'meta') {
-        webChatComponent.updateMessageMetaData(message);
-
-        totalMessages -= 1;
-      } else if (!message) {
-        webChatComponent.contentEditable = true;
-      } else {
-        if (messageIndex === 0) {
+      });
+  
+    } else if (response.data) {
+      const message = response.data;
+  
+      if (sentMessage.type === "chat_open") {
+        if (message && message.data) {
+          let typingMessage;
+  
           if (
             (webChatComponent.useBotName || webChatComponent.useBotAvatar) &&
             !message.data.hideavatar
           ) {
             const authorMsg = webChatComponent.newAuthorMessage(message);
-
+  
             webChatComponent.messageList.push(authorMsg);
           }
-
+  
+          typingMessage = {
+            author: "them",
+            type: "typing",
+            mode: webChatComponent.modeData.mode,
+            data: {
+              animate: webChatComponent.messageAnimation
+            }
+          };
+          webChatComponent.messageList.push(typingMessage);
+  
+          setTimeout(() => {
+            webChatComponent.$emit("newMessage", message);
+  
+            message.data.animate = webChatComponent.messageAnimation;
+  
+            typingMessage.type = message.type;
+            typingMessage.data = message.data;
+  
+            if (message.type === "fp-form") {
+              webChatComponent.showFullPageFormInputMessage(message);
+            }
+  
+            if (message.type === "fp-rich") {
+              webChatComponent.showFullPageRichInputMessage(message);
+            }
+  
+            webChatComponent.contentEditable = !message.data.disable_text;
+  
+            resolve(webChatComponent.messageList)
+          }, webChatComponent.messageDelay);
+        } else {
+          // If we don't get data about whether to disable the editor, turn it on
+          webChatComponent.contentEditable = true;
+        }
+      } else {
+        let typingMessage;
+  
+        if (message.data) {
+          if (
+            (webChatComponent.useBotName || webChatComponent.useBotAvatar) &&
+            !message.data.hideavatar
+          ) {
+            const authorMsg = webChatComponent.newAuthorMessage(message);
+  
+            webChatComponent.messageList.push(authorMsg);
+          }
+  
           typingMessage = {
             author: "them",
             type: "typing",
@@ -98,233 +261,82 @@ WebChatMode.prototype.sendResponseSuccess = function(response, sentMessage, webC
           };
           webChatComponent.messageList.push(typingMessage);
         }
-
+  
         setTimeout(() => {
-          webChatComponent.$emit("newMessage", message);
-
-          /* eslint-disable no-param-reassign */
-          message.data.animate = webChatComponent.messageAnimation;
-
-          if (
-            messageIndex === 0 ||
-            !webChatComponent.hideTypingIndicatorOnInternalMessages
-          ) {
+          // Only add a message to the list if it is a message object
+          if (typeof message === "object" && message !== null) {
+            webChatComponent.$emit("newMessage", message);
+  
+            message.data.animate = webChatComponent.messageAnimation;
+  
             typingMessage.type = message.type;
             typingMessage.data = message.data;
-
-            if (messageIndex === 0 && totalMessages > 1) {
-              typingMessage.data.first = true;
-            }
-
-            if (messageIndex > 0 && messageIndex < totalMessages - 1) {
-              typingMessage.data.middle = true;
-            }
-
-            if (messageIndex > 0 && messageIndex === totalMessages - 1) {
-              typingMessage.data.last = true;
-            }
-
+  
             webChatComponent.$root.$emit("scroll-down-message-list");
             setTimeout(() => {
               webChatComponent.$root.$emit("scroll-down-message-list");
             }, 50);
-          } else {
-            if (messageIndex > 0 && messageIndex === totalMessages - 1) {
-              /* eslint-disable no-param-reassign */
-              message.data.lastInternal = true;
-            }
-
-            message.mode = webChatComponent.modeData.mode;
-            webChatComponent.messageList.push(message);
           }
-
+  
           if (message.data) {
             webChatComponent.contentEditable = !message.data.disable_text;
           }
-
+  
           if (message.type === "fp-form") {
             webChatComponent.showFullPageFormInputMessage(message);
           }
-
+  
           if (message.type === "fp-rich") {
             webChatComponent.showFullPageRichInputMessage(message);
           }
-
+  
           if (message.type !== "fp-form" && message.type !== "fp-rich") {
             webChatComponent.showFullPageFormInput = false;
             webChatComponent.showFullPageRichInput = false;
             webChatComponent.showMessages = true;
           }
-
-          if (!webChatComponent.hideTypingIndicatorOnInternalMessages) {
-            if (messageIndex < totalMessages - 1) {
-              webChatComponent.$nextTick(() => {
-                webChatComponent.$nextTick(() => {
-                  typingMessage = {
-                    author: "them",
-                    type: "typing",
-                    mode: webChatComponent.modeData.mode,
-                    data: {
-                      animate: webChatComponent.messageAnimation
-                    }
-                  };
-                  webChatComponent.messageList.push(typingMessage);
-                });
-              });
+  
+          if (message.type === "longtext") {
+            if (message.data.character_limit) {
+              webChatComponent.maxInputCharacters = message.data.character_limit;
             }
+  
+            if (message.data.submit_text) {
+              webChatComponent.buttonText = message.data.submit_text;
+            }
+  
+            if (message.data.text) {
+              webChatComponent.headerText = message.data.text;
+            }
+  
+            if (message.data.placeholder) {
+              webChatComponent.placeholder = message.data.placeholder;
+            }
+  
+            if (message.data.initial_text) {
+              webChatComponent.initialText = message.data.initial_text;
+            } else {
+              webChatComponent.initialText = null;
+            }
+  
+            if (message.data.confirmation_text) {
+              webChatComponent.confirmationMessage = message.data.confirmation_text;
+            } else {
+              webChatComponent.confirmationMessage = null;
+            }
+  
+            webChatComponent.showLongTextInput = true;
+            webChatComponent.showMessages = false;
           }
-        }, (messageIndex + 1) * webChatComponent.messageDelay);
-
-        sendMessageReceivedEvent(message, webChatComponent);
-
-        index += 1;
-      }
-    });
-
-  } else if (response.data) {
-    const message = response.data;
-
-    if (sentMessage.type === "chat_open") {
-      if (message && message.data) {
-        let typingMessage;
-
-        if (
-          (webChatComponent.useBotName || webChatComponent.useBotAvatar) &&
-          !message.data.hideavatar
-        ) {
-          const authorMsg = webChatComponent.newAuthorMessage(message);
-
-          webChatComponent.messageList.push(authorMsg);
-        }
-
-        typingMessage = {
-          author: "them",
-          type: "typing",
-          mode: webChatComponent.modeData.mode,
-          data: {
-            animate: webChatComponent.messageAnimation
-          }
-        };
-        webChatComponent.messageList.push(typingMessage);
-
-        setTimeout(() => {
-          webChatComponent.$emit("newMessage", message);
-
-          message.data.animate = webChatComponent.messageAnimation;
-
-          typingMessage.type = message.type;
-          typingMessage.data = message.data;
-
-          if (message.type === "fp-form") {
-            webChatComponent.showFullPageFormInputMessage(message);
-          }
-
-          if (message.type === "fp-rich") {
-            webChatComponent.showFullPageRichInputMessage(message);
-          }
-
-          webChatComponent.contentEditable = !message.data.disable_text;
+  
+          resolve(webChatComponent.messageList)
         }, webChatComponent.messageDelay);
-      } else {
-        // If we don't get data about whether to disable the editor, turn it on
-        webChatComponent.contentEditable = true;
+        sendMessageReceivedEvent(message, webChatComponent);
       }
-    } else {
-      let typingMessage;
-
-      if (message.data) {
-        if (
-          (webChatComponent.useBotName || webChatComponent.useBotAvatar) &&
-          !message.data.hideavatar
-        ) {
-          const authorMsg = webChatComponent.newAuthorMessage(message);
-
-          webChatComponent.messageList.push(authorMsg);
-        }
-
-        typingMessage = {
-          author: "them",
-          type: "typing",
-          mode: webChatComponent.modeData.mode,
-          data: {
-            animate: webChatComponent.messageAnimation
-          }
-        };
-        webChatComponent.messageList.push(typingMessage);
-      }
-
-      setTimeout(() => {
-        // Only add a message to the list if it is a message object
-        if (typeof message === "object" && message !== null) {
-          webChatComponent.$emit("newMessage", message);
-
-          message.data.animate = webChatComponent.messageAnimation;
-
-          typingMessage.type = message.type;
-          typingMessage.data = message.data;
-
-          webChatComponent.$root.$emit("scroll-down-message-list");
-          setTimeout(() => {
-            webChatComponent.$root.$emit("scroll-down-message-list");
-          }, 50);
-        }
-
-        if (message.data) {
-          webChatComponent.contentEditable = !message.data.disable_text;
-        }
-
-        if (message.type === "fp-form") {
-          webChatComponent.showFullPageFormInputMessage(message);
-        }
-
-        if (message.type === "fp-rich") {
-          webChatComponent.showFullPageRichInputMessage(message);
-        }
-
-        if (message.type !== "fp-form" && message.type !== "fp-rich") {
-          webChatComponent.showFullPageFormInput = false;
-          webChatComponent.showFullPageRichInput = false;
-          webChatComponent.showMessages = true;
-        }
-
-        if (message.type === "longtext") {
-          if (message.data.character_limit) {
-            webChatComponent.maxInputCharacters = message.data.character_limit;
-          }
-
-          if (message.data.submit_text) {
-            webChatComponent.buttonText = message.data.submit_text;
-          }
-
-          if (message.data.text) {
-            webChatComponent.headerText = message.data.text;
-          }
-
-          if (message.data.placeholder) {
-            webChatComponent.placeholder = message.data.placeholder;
-          }
-
-          if (message.data.initial_text) {
-            webChatComponent.initialText = message.data.initial_text;
-          } else {
-            webChatComponent.initialText = null;
-          }
-
-          if (message.data.confirmation_text) {
-            webChatComponent.confirmationMessage = message.data.confirmation_text;
-          } else {
-            webChatComponent.confirmationMessage = null;
-          }
-
-          webChatComponent.showLongTextInput = true;
-          webChatComponent.showMessages = false;
-        }
-      }, webChatComponent.messageDelay);
-      sendMessageReceivedEvent(message, webChatComponent);
     }
-  }
+  })
 
-  return webChatComponent.messageList
+  //return webChatComponent.messageList
 };
 
 WebChatMode.prototype.sendResponseError = function(error, sentMessage, webChatComponent) {

--- a/resources/assets/js/store.js
+++ b/resources/assets/js/store.js
@@ -87,7 +87,7 @@ const store = new Vuex.Store({
   },
   getters: {
     lastUsefulMessage: state => {
-      const msg = state.messageList.filter(msg => msg.type !== 'typing' && msg.type !== 'author').pop()
+      const msg = state.messageList.filter(msg => msg.type && msg.type !== 'typing' && msg.type !== 'author').pop()
       return msg ? msg : {}
     }
   },

--- a/resources/assets/js/store.js
+++ b/resources/assets/js/store.js
@@ -88,6 +88,7 @@ const store = new Vuex.Store({
   getters: {
     lastUsefulMessage: state => {
       const msg = state.messageList.filter(msg => msg.type && msg.type !== 'typing' && msg.type !== 'author').pop()
+      log && console.log('lastUsefulMessage', msg)
       return msg ? msg : {}
     }
   },


### PR DESCRIPTION
The PR seeks to resolve [MMMB-58](https://greenshootlabs.atlassian.net/browse/MMMB-58). Other issues addressed include: [MMMB-89](https://greenshootlabs.atlassian.net/browse/MMMB-89), [MMMB-103](https://greenshootlabs.atlassian.net/browse/MMMB-103) and [MMMB-101](https://greenshootlabs.atlassian.net/browse/MMMB-101). Features:
- Adds skip button markup, styling and functionality
- Move the main call to the webchat service into the store so it can be called directly from components (rather than emitting an event up through the component tree)
- Convert the sendResponseSuccess function in the webchat service to a Promise that returns the messageList so that it can be added to the global state
- Add a currentMessage property to the global state that will never be a typing/author/empty response. This helps us avoid issues with empty messages inserted into the messageList (MMMB-103)
- Add a userInputType property to the global state. This allows us to control the display logic in the user input area in a much more deliberate, granular fashion. It also seeks to solve MMMB-89
- Adds a transition to the autocomplete component to manage the loading in of the results list in a visually more elegant way
- Removes an `!important` flag in the typing message styling that was overriding typing bubble background colour (MMMB-101)