### PR TITLE
Feature/session timer

### DIFF
--- a/resources/assets/js/default-webchat-settings.js
+++ b/resources/assets/js/default-webchat-settings.js
@@ -1,6 +1,7 @@
 export default {
     "url": "",
     "mobileWidth": "1",
+    "sessionDuration": 120,
     "general": {
         "url": "/web-chat",
         "teamName": "Webchat",

--- a/resources/assets/js/mixins/bootstrapFunctions.js
+++ b/resources/assets/js/mixins/bootstrapFunctions.js
@@ -1,7 +1,22 @@
 import deepMerge from 'lodash/merge';
+import Timer from './timer';
 
 export function isObject(item) {
   return (item && typeof item === 'object' && !Array.isArray(item));
+}
+
+export function initTimer(el, duration, callback) {
+  const t = new Timer(duration, callback)
+
+  el.addEventListener('click', () => {
+    t.reset()
+  })
+
+  el.addEventListener('keydown', () => {
+    t.reset()
+  })
+
+  t.start()
 }
 
 export function merge(src, tar) {

--- a/resources/assets/js/mixins/timer.js
+++ b/resources/assets/js/mixins/timer.js
@@ -1,6 +1,6 @@
 export default class Timer {
   constructor(duration, callback) {
-    this.duration = duration
+    this.duration = duration * 60000 // convert minutes to ms
     this.callback = callback
     this.timer = null
   }

--- a/resources/assets/js/mixins/timer.js
+++ b/resources/assets/js/mixins/timer.js
@@ -1,0 +1,18 @@
+export default class Timer {
+  constructor(duration, callback) {
+    this.duration = duration
+    this.callback = callback
+    this.timer = null
+  }
+
+  reset() {
+    clearTimeout(this.timer)
+    this.start()
+  }
+  start() {
+    this.timer = setTimeout(this.callback, this.duration)
+  }
+  stop() {
+    clearTimeout(this.timer)
+  }
+}

--- a/resources/assets/js/opendialog-bot-full.js
+++ b/resources/assets/js/opendialog-bot-full.js
@@ -4,6 +4,7 @@ import 'core-js/es/object';
 import {uuid} from 'vue-uuid';
 import defaultWebchatSettings from './default-webchat-settings';
 import {merge, addCssToPage, getSettings} from './mixins/bootstrapFunctions';
+import Timer from './mixins/timer';
 
 const dev = location.hostname === 'localhost'
 
@@ -14,6 +15,10 @@ if (!dev) {
         e.preventDefault(); 
         e.returnValue = '';
     });
+}
+
+function reloadChatBot() {
+    console.log('reload')
 }
 
 function openChatWindow() {
@@ -57,6 +62,17 @@ function openChatWindow() {
             }
         }
     });
+
+    // timer events
+    document.querySelector('.opendialog-chat-window').addEventListener('click', () => {
+        t.reset()
+    })
+
+    document.querySelector('.opendialog-chat-window').addEventListener('keydown', () => {
+        t.reset()
+    })
+
+    t.start()
 }
 
 if (window.openDialogSettings) {
@@ -83,6 +99,10 @@ if (window.openDialogSettings) {
 
         if (window.openDialogSettings.general.chatbotFullpageCssPath) {
             addCssToPage(window.openDialogSettings.general.chatbotFullpageCssPath);
+        }
+
+        if (window.openDialogSettings.sessionDuration) {
+            const t = new Timer(5000, reloadChatBot)
         }
 
         openChatWindow();

--- a/resources/assets/js/opendialog-bot-full.js
+++ b/resources/assets/js/opendialog-bot-full.js
@@ -3,22 +3,24 @@ import 'whatwg-fetch';
 import 'core-js/es/object';
 import {uuid} from 'vue-uuid';
 import defaultWebchatSettings from './default-webchat-settings';
-import {merge, addCssToPage, getSettings} from './mixins/bootstrapFunctions';
-import Timer from './mixins/timer';
+import {merge, addCssToPage, getSettings, initTimer} from './mixins/bootstrapFunctions';
 
 const dev = location.hostname === 'localhost'
 
 if (!dev) {
     // prompt the user when they attempt to reload/leave the page
     // this is extremely irritating whilst developing so not applicable for localhost!
-    window.addEventListener('beforeunload', e => {
-        e.preventDefault(); 
-        e.returnValue = '';
-    });
+    window.addEventListener('beforeunload', showReloadWarning);
+}
+
+function showReloadWarning(e) {
+    e.preventDefault(); 
+    e.returnValue = '';
 }
 
 function reloadChatBot() {
-    console.log('reload')
+    window.removeEventListener('beforeunload', showReloadWarning);
+    location.reload()
 }
 
 function openChatWindow() {
@@ -62,17 +64,6 @@ function openChatWindow() {
             }
         }
     });
-
-    // timer events
-    document.querySelector('.opendialog-chat-window').addEventListener('click', () => {
-        t.reset()
-    })
-
-    document.querySelector('.opendialog-chat-window').addEventListener('keydown', () => {
-        t.reset()
-    })
-
-    t.start()
 }
 
 if (window.openDialogSettings) {
@@ -102,7 +93,8 @@ if (window.openDialogSettings) {
         }
 
         if (window.openDialogSettings.sessionDuration) {
-            const t = new Timer(5000, reloadChatBot)
+            const el = document.querySelector('.opendialog-chat-window')
+            initTimer(el, window.openDialogSettings.sessionDuration, reloadChatBot)
         }
 
         openChatWindow();


### PR DESCRIPTION
This PR seeks to resolve the FE requirement for [MMMB-16](https://greenshootlabs.atlassian.net/browse/MMMB-16) by:
- Adding a Timer class with start/stop/reset functionality
- Adding a `sessionDuration` prop to the defaultWebchatSettings that takes a duration in minutes as its value
- Setting up click/keydown listeners on the main chatbot DOM element that reset the timer on interaction
- Adding functionality that reloads the page once the timer expires