### PR TITLE
Ensuring addition of custom stylesheet happens within the iframe

### DIFF
--- a/resources/assets/js/components/OpenDialogChat.vue
+++ b/resources/assets/js/components/OpenDialogChat.vue
@@ -112,13 +112,14 @@
 
 <script>
 import axios from 'axios';
-import { mapState } from 'vuex';
+import {mapState} from 'vuex';
 
 import cssVars from 'css-vars-ponyfill';
 
 import Comments from '@/components/Comments';
 import WebChat from '@/components/WebChat';
 import SessionStorageMixin from '../mixins/SessionStorageMixin';
+import {addCssToPage} from "../mixins/bootstrapFunctions";
 
 const { detect } = require('detect-browser');
 const jstz = require('jstz');
@@ -176,6 +177,7 @@ export default {
       showRestartButton: false,
       showTabs: false,
       timezoneInitialised: false,
+      chatBotCssPath: null,
       useBotAvatar: false,
       useHumanAvatar: false,
       useBotName: false,
@@ -244,6 +246,9 @@ export default {
       if (oldId !== '' && newId !== oldId) {
         this.commentsKey += 1;
       }
+    },
+    chatBotCssPath(newPath) {
+      addCssToPage(newPath);
     },
   },
   created() {
@@ -561,6 +566,10 @@ export default {
 
         if (general.useBotAvatar) {
           this.useBotAvatar = general.useBotAvatar;
+        }
+
+        if (general.chatbotCssPath) {
+          this.chatBotCssPath = general.chatbotCssPath;
         }
 
         if (general.useHumanAvatar) {

--- a/resources/assets/js/opendialog-bot.js
+++ b/resources/assets/js/opendialog-bot.js
@@ -78,10 +78,6 @@ const defaultBootstrapFunctions = {
         loadSettings: window.openDialogSettings,
         newPathname: window.location.pathname,
       }, '*');
-
-      if (window.openDialogSettings.general.chatbotCssPath) {
-        addCssToPage(window.openDialogSettings.general.chatbotCssPath, ifrm.contentWindow.document)
-      }
     };
 
     listeners.message = async (event) => {


### PR DESCRIPTION
This PR ensures that we avoid cross-origin frame errors when trying to add custom CSS to a bot. Previously we attempted to access the iFrame from the parent page (causing the error), but now we get the path from the Webchat settings within the iFrame and add it from there.