### PR TITLE
Fix/autocomplete escaping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
 
       - run: curl https://www.npmjs.com/install.sh | sudo sh
 
+
+
+
       - restore_cache:
           keys:
             - v1-node-dependencies-{{ checksum "package-lock.json" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
       - run: sudo apt-get update
       - run: sudo apt install -y libsqlite3-dev
       - run: sudo composer self-update
+      - run: sudo composer self-update --rollback
 
       - run: sudo apt-get install nodejs -y
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,8 +20,7 @@ jobs:
       - checkout
       - run: sudo apt-get update
       - run: sudo apt install -y libsqlite3-dev
-      - run: sudo composer self-update
-      - run: sudo composer self-update --rollback
+      - run: sudo composer self-update 1.10.16
 
       - run: sudo apt-get install nodejs -y
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,17 +29,17 @@ jobs:
 
 
 
+      # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-node-dependencies-{{ checksum "package-lock.json" }}
-            - v1-node-dependencies-
-            -
+            - v1-dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "composer.lock" }}
+
       - run: npm install
 
       - save_cache:
           paths:
             - ./node_modules
-          key: v1-node-dependencies-{{ checksum "package-lock.json" }}
+          key: v1-dependencies-{{ .Environment.CACHE_VERSION }}-{{ checksum "composer.lock" }}
 
       - run: npm run dev
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,7 +31,4 @@
         <env name="APP_KEY" value="AckfSECXIvnK5r28GVIWUAxmbBSjTsmF"/>
         <env name="PACKAGE_NAME" value="TestDialog"/>
     </php>
-    <logging>
-        <log type="coverage-text" target="build/coverage.txt"/>
-    </logging>
 </phpunit>

--- a/resources/assets/js/components/messages/Autocomplete.vue
+++ b/resources/assets/js/components/messages/Autocomplete.vue
@@ -1,14 +1,14 @@
 <template>
   <div class="od-autocomplete" :class="{'od-autocomplete--expanded': results.length}">
     <div class="od-autocomplete__search-container">
-      <input 
-        :value="searchTerm" 
-        type="text" 
-        :placeholder="data.placeholder" 
+      <input
+        :value="searchTerm"
+        type="text"
+        :placeholder="data.placeholder"
         class="od-autocomplete__search"
         :maxlength="textLimit ? textLimit : ''"
         @keyup.enter.prevent="_handleClick()"
-        @keydown.tab="results.length ? selectFirst() : false" 
+        @keydown.tab="results.length ? selectFirst() : false"
         @keyup="search()"
         @input="searchTerm = $event.target.value"
         @scroll="_scroll"
@@ -27,12 +27,12 @@
       <p>{{data.title}}</p>
       <perfect-scrollbar class="od-autocomplete__scrollable">
         <ul class="od-autocomplete__results-list">
-          <li 
-            tabindex="0" 
-            @keyup.tab="searchTerm = result.name" 
-            @keyup.enter="_handleClick(result.name)" 
-            @click="_handleClick(result.name)" 
-            v-for="(result, i) in results" 
+          <li
+            tabindex="0"
+            @keyup.tab="searchTerm = result.name"
+            @keyup.enter="_handleClick(result.name)"
+            @click="_handleClick(result.name)"
+            v-for="(result, i) in results"
             :key="i">
               {{result.name}}
             </li>
@@ -70,15 +70,15 @@ export default {
   methods: {
     _handleClick(term) {
       let str = term ? term.trim() : this.searchTerm.trim()
-      
+
       if (!str.length) {
         return false
       }
 
       const attr = str.replace(/\./g, "\\.")
 
-      this.message.data.callback_value = term ? `${this.message.data.attribute_name}.${term}` : `${this.message.data.attribute_name}.${attr}`
-      this.message.data.callback_text = term ? term : str
+      this.message.data.callback_value = `${this.message.data.attribute_name}.${attr}`
+      this.message.data.callback_text = str
 
       this.onButtonClick(false, this.message.data)
       this.searchTerm = ''
@@ -106,7 +106,7 @@ export default {
 
       const l = this.searchTerm.length
       const firstResult = this.results.length ? this.results[0].name.toLowerCase() : null
-      
+
       return firstResult && firstResult.startsWith(this.searchTerm.toLowerCase()) ? this.results[0].name.slice(l) : ''
     },
     endpoint() {
@@ -117,7 +117,7 @@ export default {
       });
 
       str += `${this.data.query_param_name}=${this.searchTerm}`
-      
+
       return str
     },
     ...mapState({


### PR DESCRIPTION
This PR simplifies how the AutoComplete component escapes the value that forms part of the message callback. We will always want to be escaping the "." regardless of how the input is added - verbatim or otherwise