### PR TITLE
url encodes query param before calling API

### DIFF
--- a/resources/assets/js/components/messages/Autocomplete.vue
+++ b/resources/assets/js/components/messages/Autocomplete.vue
@@ -116,8 +116,10 @@ export default {
         str += `${obj.name}=${obj.value}&`
       });
 
-      str += `${this.data.query_param_name}=${this.searchTerm}`
-      
+      let searchTerm = encodeURIComponent(this.searchTerm)
+
+      str += `${this.data.query_param_name}=${searchTerm}`
+
       return str
     },
     ...mapState({


### PR DESCRIPTION
This PR fixes an issue where query params sent to the proxy API were not being urlencoded. This was breaking some searches that included ampersands as they were considered a new query param