### PR TITLE
Fix/auto fix escaping no render html

### DIFF
--- a/resources/assets/js/components/messages/TextMessage.vue
+++ b/resources/assets/js/components/messages/TextMessage.vue
@@ -14,8 +14,9 @@
     }]"
     v-linkified:options="{ format: function (value, type) { return '<span>' + value + '</span>'; } }"
   >
-    <span class="fade-enter-active" v-html="data.text"></span>
-    <!-- <p v-if="data.meta" class="sc-message--meta">{{data.meta}}</p> -->
+    <span class="fade-enter-active" v-if="this.author === 'me'">{{ data.text }}</span>
+    <span class="fade-enter-active" v-html="data.text" v-else></span>
+
       <p v-if="data.meta" class="sc-message--meta" >{{data.meta}}</p>
   </div>
 </template>

--- a/resources/assets/js/components/messages/responses/ButtonResponseMessage.vue
+++ b/resources/assets/js/components/messages/responses/ButtonResponseMessage.vue
@@ -7,7 +7,8 @@
         reap: this.author === 'them',
     }]"
   >
-    <div class="button" v-html="data.text"></div>
+    <div class="button" v-if="author==='me'">{{ data.text }}</div>
+    <div class="button" v-html="data.text" v-else></div>
   </div>
 </template>
 

--- a/resources/assets/js/components/messages/responses/FormResponseMessage.vue
+++ b/resources/assets/js/components/messages/responses/FormResponseMessage.vue
@@ -5,7 +5,8 @@
         emit : this.author === 'me',
         reap: this.author === 'them',
     }]">
-    <div class="form-response" v-html="data.text"></div>
+    <div class="form-response" v-if="author==='me'">{{ data.text }}</div>
+    <div class="form-response" v-else v-html="data.text"></div>
   </div>
 </template>
 


### PR DESCRIPTION
Sorry for the badly named branch here - this is an extension of the `fix/autocomplete-escaping` branch with some cherrypicked work from the `fix/prevent-parsing-user-input-html` branch to prevent rendering of any user input as HTML.

@patshone-gsl - based on our conversation, this logic will need to be updated to always allow button text to be rendered as HTML and to update the autocomplete logic so that it uses a text message as a response instead of a button responsese